### PR TITLE
initial commit of chalice-graphql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,3 @@ script:
 after_success:
   - pip install coveralls
   - coveralls
-
-deploy:
-  provider: pypi
-  user: syrusakbary
-  on:
-    tags: true
-  password:
-    secure: GB3YHihKAbmfh9kzMxzsZQDMf5h1aIJYwESfaYMc4DjMA1Qms+ZhBN2RiH3irwJ6FW47ZsS/O6ZsrlNxu75J/Mc1NJfzFev1d0xt7cYp+s0umYHhheelR6wmP8KOt3ugK7qmWuk5bykljpxsRKzKJCvGH+LOM7mDQy3NZOfYPTAM2znWjuBr+X4iUv6pUCKk5N20GBbs9T+jNttE7K8TH4zuXCWxgbE7xVHth76pB5Q/9FZkB8hZQ7K2esO3QyajDO7FzsOk8Z/jXRJ3MOxZCI3vGgmSzKTH4fMqmSrtyr1sCaBO5tgS8ytqQBjsuV1vIWl+75bXrAXfdkin63zMne4Rsb+uSWj3djP+iy2yML8a2mWMizxr803v8lwaGnMZ26f4rwdZnHGUPlTp3geVKq23vidVTQwF8v2o1rHvtdD4KJ5Mi41TXAfnih3XUf+fCTXdbAXKqweDuhcZg09/r7U/6zo76wjnt1cePPZe63/xG6bAVQ+Gz1J+HZz55ofDZV9g9kwyNll4Jfdzj9hUHO8AfBMvXQJewRj/LbzbmbBp5peov+DFhx7TWofvqxjreVKxDiDN89pC+WKy5BwZMcpB3dRVGuZ25ZrENLgoTX7W4PHPb1+OF4edP6xM44egcJLamk7vhvpZQqukJGRQZFtIMw8KIkC7OWzpCFIXN08=

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include README.md
 include tox.ini
 include Makefile
 
-recursive-include flask_graphql *.py
+recursive-include chalice_graphql *.py
 recursive-include tests *.py
 
 global-exclude *.py[co] __pycache__

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ dev-setup:
 	python pip install -e ".[test]"
 
 tests:
-	py.test tests --cov=flask_graphql -vv
+	py.test tests --cov=chalice_graphql -vv

--- a/README.md
+++ b/README.md
@@ -1,58 +1,54 @@
-# Flask-GraphQL
+# Chalice-GraphQL
 
-Adds GraphQL support to your Flask application.
+Adds [GraphQL] support to your [Chalice] application.
+
+Based on [flask-graphql] by [Syrus Akbary] and [aiohttp-graphql] by [Devin Fee].
 
 [![travis][travis-image]][travis-url]
-[![pypi][pypi-image]][pypi-url]
-[![Anaconda-Server Badge][conda-image]][conda-url]
 [![coveralls][coveralls-image]][coveralls-url]
 
-[travis-image]: https://travis-ci.org/graphql-python/flask-graphql.svg?branch=master
-[travis-url]: https://travis-ci.org/graphql-python/flask-graphql
-[pypi-image]: https://img.shields.io/pypi/v/flask-graphql.svg?style=flat
-[pypi-url]: https://pypi.org/project/flask-graphql/
-[coveralls-image]: https://coveralls.io/repos/graphql-python/flask-graphql/badge.svg?branch=master&service=github
-[coveralls-url]: https://coveralls.io/github/graphql-python/flask-graphql?branch=master
-[conda-image]: https://img.shields.io/conda/vn/conda-forge/flask-graphql.svg
-[conda-url]: https://anaconda.org/conda-forge/flask-graphql
+[GraphQL]: http://graphql.org/
+[Chalice]: https://aws.github.io/chalice/
+[Syrus Akbary]: https://github.com/syrusakbary
+[Devin Fee]: https://github.com/dfee
+[travis-image]: https://travis-ci.org/jrbeilke/chalice-graphql.svg?branch=master
+[travis-url]: https://travis-ci.org/jrbeilke/chalice-graphql
+[coveralls-image]: https://coveralls.io/repos/github/jrbeilke/chalice-graphql/badge.svg?branch=master
+[coveralls-url]: https://coveralls.io/github/jrbeilke/chalice-graphql?branch=master
 
 ## Usage
 
-Just use the `GraphQLView` view from `flask_graphql`
+Add the `GraphQLView` from `chalice_graphql` to dispatch requests for your desired route(s)
 
 ```python
-from flask import Flask
-from flask_graphql import GraphQLView
+from chalice import Chalice
+from chalice_graphql import GraphQLView
 
 from schema import schema
 
-app = Flask(__name__)
+app = Chalice(app_name='helloworld')
 
-app.add_url_rule('/graphql', view_func=GraphQLView.as_view(
-    'graphql',
-    schema=schema,
-    graphiql=True,
-))
+@app.route(
+    '/graphql',
+    methods=['GET', 'POST'],
+    content_types=['application/graphql', 'application/json', 'application/x-www-form-urlencoded']
+)
+def graphql():
+    gql_view = GraphQLView(schema=schema, graphiql=True)
+    return gql_view.dispatch_request(app.current_request)
 
 # Optional, for adding batch query support (used in Apollo-Client)
-app.add_url_rule('/graphql/batch', view_func=GraphQLView.as_view(
-    'graphql',
-    schema=schema,
-    batch=True
-))
-
-if __name__ == '__main__':
-    app.run()
+@app.route(
+    '/graphql/batch',
+    methods=['GET', 'POST'],
+    content_types=['application/graphql', 'application/json', 'application/x-www-form-urlencoded']
+)
+def graphql_batch():
+    gql_view = GraphQLView(schema=schema, batch=True)
+    return gql_view.dispatch_request(app.current_request)
 ```
 
 This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
-
-### Special Note for Graphene v3
-
-If you are using the `Schema` type of [Graphene](https://github.com/graphql-python/graphene) library, be sure to use the `graphql_schema` attribute to pass as schema on the `GraphQLView` view. Otherwise, the `GraphQLSchema` from `graphql-core` is the way to go.
-
-More info at [Graphene v3 release notes](https://github.com/graphql-python/graphene/wiki/v3-release-notes#graphene-schema-no-longer-subclasses-graphqlschema-type) and [GraphQL-core 3 usage](https://github.com/graphql-python/graphql-core#usage).
-
 
 ### Supported options for GraphQLView
 
@@ -73,16 +69,3 @@ More info at [Graphene v3 release notes](https://github.com/graphql-python/graph
  * `default_query`: An optional GraphQL string to use when no query is provided and no stored query exists from a previous session. If not provided, GraphiQL will use its own default query.
 * `header_editor_enabled`: An optional boolean which enables the header editor when true. Defaults to **false**.
 * `should_persist_headers`:  An optional boolean which enables to persist headers to storage when true. Defaults to **false**.
-
-You can also subclass `GraphQLView` and overwrite `get_root_value(self, request)` to have a dynamic root value
-per request.
-
-```python
-class UserRootValue(GraphQLView):
-    def get_root_value(self, request):
-        return request.user
-
-```
-
-## Contributing
-Since v3, `flask-graphql` code lives at [graphql-server](https://github.com/graphql-python/graphql-server) repository to keep any breaking change on the base package on sync with all other integrations. In order to contribute, please take a look at [CONTRIBUTING.md](https://github.com/graphql-python/graphql-server/blob/master/CONTRIBUTING.md).

--- a/chalice_graphql/__init__.py
+++ b/chalice_graphql/__init__.py
@@ -1,0 +1,3 @@
+from .graphqlview import GraphQLView
+
+__all__ = ['GraphQLView']

--- a/chalice_graphql/graphqlview.py
+++ b/chalice_graphql/graphqlview.py
@@ -1,0 +1,182 @@
+import copy
+from collections.abc import MutableMapping
+from functools import partial
+from typing import List
+from urllib.parse import parse_qsl
+
+from chalice import Response
+from graphql.error import GraphQLError
+from graphql.type.schema import GraphQLSchema
+
+from graphql_server import (
+    GraphQLParams,
+    HttpQueryError,
+    encode_execution_results,
+    format_error_default,
+    json_encode,
+    load_json_body,
+    run_http_query,
+)
+from graphql_server.render_graphiql import (
+    GraphiQLConfig,
+    GraphiQLData,
+    GraphiQLOptions,
+    render_graphiql_sync,
+)
+
+
+class GraphQLView:
+    schema = None
+    root_value = None
+    context = None
+    pretty = False
+    graphiql = False
+    graphiql_version = None
+    graphiql_template = None
+    graphiql_html_title = None
+    middleware = None
+    batch = False
+    subscriptions = None
+    headers = None
+    default_query = None
+    header_editor_enabled = None
+    should_persist_headers = None
+
+    methods = ["GET", "POST", "PUT", "DELETE"]
+
+    format_error = staticmethod(format_error_default)
+    encode = staticmethod(json_encode)
+
+    def __init__(self, **kwargs):
+        super(GraphQLView, self).__init__()
+        for key, value in kwargs.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+
+        assert isinstance(
+            self.schema, GraphQLSchema
+        ), "A Schema is required to be provided to GraphQLView."
+
+    def get_root_value(self):
+        return self.root_value
+
+    def get_context(self, request):
+        context = (
+            copy.copy(self.context)
+            if self.context and isinstance(self.context, MutableMapping)
+            else {}
+        )
+        if isinstance(context, MutableMapping) and "request" not in context:
+            context.update({"request": request})
+        return context
+
+    def get_middleware(self):
+        return self.middleware
+
+    def dispatch_request(self, request):
+        try:
+            request_method = request.method.lower()
+            data = self.parse_body(request)
+            is_graphiql = self.is_graphiql(request)
+            is_pretty = self.is_pretty(request)
+
+            all_params: List[GraphQLParams]
+            execution_results, all_params = run_http_query(
+                self.schema,
+                request_method,
+                data,
+                query_data=request.query_params,
+                batch_enabled=self.batch,
+                catch=is_graphiql,
+                # Execute options
+                root_value=self.get_root_value(),
+                context_value=self.get_context(request),
+                middleware=self.get_middleware(),
+            )
+            result, status_code = encode_execution_results(
+                execution_results,
+                is_batch=isinstance(data, list),
+                format_error=self.format_error,
+                encode=partial(self.encode, pretty=is_pretty),  # noqa
+            )
+
+            if is_graphiql:
+                graphiql_data = GraphiQLData(
+                    result=result,
+                    query=getattr(all_params[0], "query"),
+                    variables=getattr(all_params[0], "variables"),
+                    operation_name=getattr(all_params[0], "operation_name"),
+                    subscription_url=self.subscriptions,
+                    headers=self.headers,
+                )
+                graphiql_config = GraphiQLConfig(
+                    graphiql_version=self.graphiql_version,
+                    graphiql_template=self.graphiql_template,
+                    graphiql_html_title=self.graphiql_html_title,
+                    jinja_env=None,
+                )
+                graphiql_options = GraphiQLOptions(
+                    default_query=self.default_query,
+                    header_editor_enabled=self.header_editor_enabled,
+                    should_persist_headers=self.should_persist_headers,
+                )
+                source = render_graphiql_sync(
+                    data=graphiql_data, config=graphiql_config, options=graphiql_options
+                )
+                return Response(source, headers={'Content-Type': 'text/html'})
+
+            return Response(result, status_code=status_code, headers={'Content-Type': 'application/json'})
+
+        except HttpQueryError as e:
+            parsed_error = GraphQLError(e.message)
+            headers = {}
+            if e.headers is not None:
+                headers.update(e.headers)
+            return Response(
+                self.encode(dict(errors=[self.format_error(parsed_error)])),
+                status_code=e.status_code,
+                headers=headers.update({'Content-Type': 'application/json'}),
+            )
+
+    @staticmethod
+    def parse_body(request):
+        content_type = request.headers.get('content-type', '')
+        if "application/graphql" in content_type:
+            return {"query": request.raw_body.decode("utf8")}
+
+        elif "application/json" in content_type:
+            return load_json_body(request.raw_body.decode("utf8"))
+
+        elif "application/x-www-form-urlencoded" in content_type:
+            return dict(parse_qsl(request.raw_body.decode("utf8")))
+
+        # TODO: Chalice lacks support for multipart requests
+        # https://github.com/aws/chalice/issues/796
+#        elif content_type == "multipart/form-data":
+#            return request.json_body
+
+        return {}
+
+    def is_graphiql(self, request):
+        return all(
+            [
+                self.graphiql,
+                request.method.lower() == "get",
+                request.query_params is None or request.query_params.get('raw') is None,
+                any(
+                    [
+                        "text/html" in request.headers.get("accept", {}),
+                        "*/*" in request.headers.get("accept", {}),
+                    ]
+                ),
+            ]
+        )
+
+    def is_pretty(self, request):
+        return any(
+            [
+              self.pretty,
+              self.is_graphiql(request),
+              request.query_params is not None and request.query_params.get("pretty")
+            ]
+        )

--- a/flask_graphql/__init__.py
+++ b/flask_graphql/__init__.py
@@ -1,3 +1,0 @@
-from graphql_server.flask.graphqlview import GraphQLView
-
-__all__ = ['GraphQLView']

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    "graphql-server[flask]>=3.0.0b1",
+    "chalice>=1.21.4",
+    "graphql-server>=3.0.0b1",
 ]
 
 tests_requires = [
     "pytest>=5.4,<5.5",
     "pytest-cov>=2.8,<3",
+    "Jinja2>=2.10.1,<3",
 ]
 
 dev_requires = [
@@ -19,18 +21,18 @@ with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 setup(
-    name="Flask-GraphQL",
-    version="2.0.1",
-    description="Adds GraphQL support to your Flask application",
+    name="Chalice-GraphQL",
+    version="0.1.0",
+    description="Adds GraphQL support to your Chalice application",
     long_description=readme,
     long_description_content_type="text/markdown",
-    url="https://github.com/graphql-python/flask-graphql",
-    download_url="https://github.com/graphql-python/flask-graphql/releases",
-    author="Syrus Akbary",
-    author_email="me@syrusakbary.com",
+    url="https://github.com/jrbeilke/chalice-graphql",
+    download_url="https://github.com/jrbeilke/chalice-graphql/releases",
+    author="Jon Beilke",
+    author_email="jrbeilke@gmail.com",
     license="MIT",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python :: 3.6",
@@ -38,7 +40,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",
     ],
-    keywords="api graphql protocol rest flask",
+    keywords="api graphql protocol rest chalice",
     packages=find_packages(exclude=["tests"]),
     install_requires=install_requires,
     tests_require=tests_requires,

--- a/tests/app.py
+++ b/tests/app.py
@@ -1,18 +1,28 @@
-from flask import Flask
+from chalice import Chalice
 
-from flask_graphql import GraphQLView
+from chalice_graphql import GraphQLView
 from tests.schema import Schema
 
+app = Chalice(app_name='helloworld')
 
-def create_app(path="/graphql", **kwargs):
-    app = Flask(__name__)
-    app.debug = True
-    app.add_url_rule(
-        path, view_func=GraphQLView.as_view("graphql", schema=Schema, **kwargs)
-    )
-    return app
+@app.route('/')
+def index():
+    return {'hello': 'world'}
 
+@app.route(
+    '/graphql',
+    methods=['GET', 'POST', 'PUT'],
+    content_types=['application/graphql', 'application/json', 'application/x-www-form-urlencoded', 'text/plain']
+)
+def graphql():
+    gql_view = GraphQLView(schema=Schema, graphiql=True)
+    return gql_view.dispatch_request(app.current_request)
 
-if __name__ == "__main__":
-    app = create_app(graphiql=True)
-    app.run()
+@app.route(
+    '/graphql/batch',
+    methods=['GET', 'POST'],
+    content_types=['application/graphql', 'application/json', 'application/x-www-form-urlencoded', 'text/plain']
+)
+def graphql_batch():
+    gql_view = GraphQLView(schema=Schema, batch=True)
+    return gql_view.dispatch_request(app.current_request)

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -14,7 +14,7 @@ QueryRootType = GraphQLObjectType(
         "thrower": GraphQLField(GraphQLNonNull(GraphQLString), resolve=resolve_raises),
         "request": GraphQLField(
             GraphQLNonNull(GraphQLString),
-            resolve=lambda obj, info: info.context["request"].args.get("q"),
+            resolve=lambda obj, info: info.context["request"].query_params.get("q"),
         ),
         "context": GraphQLField(
             GraphQLObjectType(

--- a/tox.ini
+++ b/tox.ini
@@ -11,19 +11,19 @@ setenv =
 install_command = python -m pip install --pre --ignore-installed {opts} {packages}
 deps = -e.[test]
 commands = 
-    pytest tests --cov-report=term-missing --cov=flask_graphql {posargs}
+    pytest tests --cov-report=term-missing --cov=chalice_graphql {posargs}
 
 [testenv:flake8]
 basepython=python3.8
 deps = -e.[dev]
 commands =
-    flake8 setup.py flask_graphql tests
+    flake8 setup.py chalice_graphql tests
 
 [testenv:import-order]
 basepython=python3.8
 deps = -e.[dev]
 commands =
-    isort -rc flask_graphql/ tests/
+    isort -rc chalice_graphql/ tests/
 
 [testenv:manifest]
 basepython = python3.8


### PR DESCRIPTION
- Adds support for most common use cases of GraphQL + Chalice including graphql, json, and form posts
- A few pending TODOs waiting on upstream changes/support being added to Chalice for things like `multipart/form-data` requests